### PR TITLE
debian_harden.sh: use disable with update-rc.d instead of remove

### DIFF
--- a/debian_harden.sh
+++ b/debian_harden.sh
@@ -89,13 +89,13 @@ purge_at() {
 }
 
 disable_avahi() {
-    update-rc.d -f avahi-daemon remove
+    update-rc.d -f avahi-daemon disable
     # The Avahi daemon provides mDNS/DNS-SD discovery support
     # (Bonjour/Zeroconf) allowing applications to discover services on the network.
 }
 
 disable_exim_pckgs() {
-    update-rc.d -f exim4 remove
+    update-rc.d -f exim4 disable
     }
 
 process_accounting() {


### PR DESCRIPTION
remove will be reverted at package upgrade, and does not affect Upstart jobs or systemd services.
